### PR TITLE
🚀 4단계 - 리팩터링

### DIFF
--- a/calculator/src/main/java/edu/nextstep/camp/calculator/CalculatorActivity.kt
+++ b/calculator/src/main/java/edu/nextstep/camp/calculator/CalculatorActivity.kt
@@ -23,14 +23,9 @@ class CalculatorActivity : AppCompatActivity() {
             viewModel = calculatorVM
         }
         setContentView(binding.root)
-        initView()
-
+        initRecyclerView()
         observeExpressionHistory()
         observeIncompleteExpressionErrorEvent()
-    }
-
-    private fun initView() {
-        initRecyclerView()
     }
 
     private fun initRecyclerView() {

--- a/calculator/src/test/java/edu/nextstep/camp/calculator/CalculatorViewModelTest.kt
+++ b/calculator/src/test/java/edu/nextstep/camp/calculator/CalculatorViewModelTest.kt
@@ -2,7 +2,7 @@ package edu.nextstep.camp.calculator
 
 import com.google.common.truth.Truth.assertThat
 import edu.nextstep.camp.calculator.data.datasource.local.ExpressionHistoryLocalDataSource
-import edu.nextstep.camp.calculator.data.repository.ExpressionHistoryRepositoryImpl
+import edu.nextstep.camp.calculator.data.di.RepositoryInjector
 import edu.nextstep.camp.calculator.domain.Expression
 import edu.nextstep.camp.calculator.domain.Operator
 import edu.nextstep.camp.calculator.domain.model.ExpressionHistory
@@ -31,7 +31,7 @@ class CalculatorViewModelTest {
     @Before
     fun setUp() {
         val expressionHistoryLocalDataSource: ExpressionHistoryLocalDataSource = mockk()
-        expressionHistoryRepository = ExpressionHistoryRepositoryImpl(
+        expressionHistoryRepository = RepositoryInjector.provideExpressionHistoryRepository(
             ioDispatcher = UnconfinedTestDispatcher(mainDispatcherRule.testDispatcher.scheduler),
             expressionHistoryLocalDataSource = expressionHistoryLocalDataSource
         )

--- a/data/src/main/java/edu/nextstep/camp/calculator/data/CalculatorDataBase.kt
+++ b/data/src/main/java/edu/nextstep/camp/calculator/data/CalculatorDataBase.kt
@@ -3,7 +3,6 @@ package edu.nextstep.camp.calculator.data
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import edu.nextstep.camp.calculator.data.model.ExpressionHistoryEntity
-import edu.nextstep.camp.calculator.domain.model.ExpressionHistory
 import edu.nextstep.camp.calculator.data.service.ExpressionHistoryDAO
 
 @Database(entities = [ExpressionHistoryEntity::class], version = 1)

--- a/data/src/main/java/edu/nextstep/camp/calculator/data/datasource/local/ExpressionHistoryLocalDataSourceImpl.kt
+++ b/data/src/main/java/edu/nextstep/camp/calculator/data/datasource/local/ExpressionHistoryLocalDataSourceImpl.kt
@@ -5,7 +5,7 @@ import edu.nextstep.camp.calculator.data.model.ExpressionHistoryEntity
 import edu.nextstep.camp.calculator.data.service.ExpressionHistoryDAO
 import edu.nextstep.camp.calculator.domain.model.ExpressionHistory
 
-class ExpressionHistoryLocalDataSourceImpl(
+internal class ExpressionHistoryLocalDataSourceImpl(
     private val expressionHistoryDAO: ExpressionHistoryDAO
 ) : ExpressionHistoryLocalDataSource {
     override suspend fun getAll(): List<ExpressionHistory> = expressionHistoryDAO.getAll().mapper()

--- a/data/src/main/java/edu/nextstep/camp/calculator/data/di/RepositoryInjector.kt
+++ b/data/src/main/java/edu/nextstep/camp/calculator/data/di/RepositoryInjector.kt
@@ -3,9 +3,17 @@ package edu.nextstep.camp.calculator.data.di
 import edu.nextstep.camp.calculator.data.datasource.local.ExpressionHistoryLocalDataSource
 import edu.nextstep.camp.calculator.data.repository.ExpressionHistoryRepositoryImpl
 import edu.nextstep.camp.calculator.domain.repository.ExpressionHistoryRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 object RepositoryInjector {
 
-    fun provideExpressionHistoryRepository(expressionHistoryLocalDataSource: ExpressionHistoryLocalDataSource): ExpressionHistoryRepository =
-        ExpressionHistoryRepositoryImpl(expressionHistoryLocalDataSource)
+    fun provideExpressionHistoryRepository(
+        expressionHistoryLocalDataSource: ExpressionHistoryLocalDataSource,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ): ExpressionHistoryRepository =
+        ExpressionHistoryRepositoryImpl(
+            expressionHistoryLocalDataSource = expressionHistoryLocalDataSource,
+            ioDispatcher = ioDispatcher
+        )
 }

--- a/data/src/main/java/edu/nextstep/camp/calculator/data/repository/ExpressionHistoryRepositoryImpl.kt
+++ b/data/src/main/java/edu/nextstep/camp/calculator/data/repository/ExpressionHistoryRepositoryImpl.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class ExpressionHistoryRepositoryImpl(
+internal class ExpressionHistoryRepositoryImpl(
     private val expressionHistoryLocalDataSource: ExpressionHistoryLocalDataSource,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ExpressionHistoryRepository {


### PR DESCRIPTION
# 개요
- calculator 모듈은 data 모듈의 구현체에 의존하지 않아야 한다.
    - 모듈 간 의존성은 상관없음
    - 즉, calculator 모듈이 data 모듈에 의존해도 되지만 구현체 클래스는 참조해서는 안됨
- data 모듈의 구현체는 모두 internal class여야 한다.#114 

## 작업내용
- step3: initView 메소드를 제거하여 불필요한 간접호출 제거
- step4: data 모듈의 구현체 모두 internal 접근제어자 추가
- step4: repositoryInjector클래스의 메소드 매개변수에 Coroutine Dispatcher 추가
- step4: testcode에 repository 초기화 로직 수정